### PR TITLE
Enable libvorbis and libmp3lame encoders

### DIFF
--- a/ffprobe.config
+++ b/ffprobe.config
@@ -34,6 +34,8 @@
 --enable-encoder=pcm_s16le
 --enable-encoder=pcm_u8
 --enable-encoder=wmav2
+--enable-encoder=libvorbis
+--enable-encoder=libmp3lame
 
 ########################################################################################################################
 ### Decoders


### PR DESCRIPTION
Adding libvorbis allows encoding ogg
Adding libmp3lame allows encoding mp3